### PR TITLE
docs: 更新模型列表和添加 Claude Code 对接指南

### DIFF
--- a/iflow2api/proxy.py
+++ b/iflow2api/proxy.py
@@ -107,8 +107,10 @@ class IFlowProxy:
         使用 iFlow-Cli User-Agent 可以解锁这些高级模型。
         """
         # iFlow CLI 支持的模型列表 (来源: iflow-cli SUPPORTED_MODELS)
+        # https://github.com/iflow-ai/iflow-cli/blob/main/src/models.ts
+        # 2026.2.15 更新
         models = [
-            {"id": "glm-4.7", "name": "GLM-4.7", "description": "智谱 GLM-4.7 (推荐)"},
+            {"id": "glm-5", "name": "GLM-5", "description": "智谱 GLM-5 (推荐)"},
             {
                 "id": "iFlow-ROME-30BA3B",
                 "name": "iFlow-ROME-30BA3B",
@@ -130,14 +132,14 @@ class IFlowProxy:
                 "description": "Moonshot Kimi K2 思考模型",
             },
             {
-                "id": "minimax-m2.1",
-                "name": "MiniMax-M2.1",
-                "description": "MiniMax M2.1",
+                "id": "minimax-m2.5",
+                "name": "MiniMax-M2.5",
+                "description": "MiniMax M2.5",
             },
             {
-                "id": "kimi-k2-0905",
-                "name": "Kimi-K2-0905",
-                "description": "Moonshot Kimi K2 0905",
+                "id": "kimi-k2.5",
+                "name": "Kimi-K2.5",
+                "description": "Moonshot Kimi K2.5",
             },
         ]
 


### PR DESCRIPTION
- 更新支持的模型列表（glm-4.7 → glm-5, minimax-m2.1 → m2.5, kimi-k2-0905 → k2.5）
- 添加 Claude Code 配置和使用指南
- 实现 Anthropic Messages API 请求体到 OpenAI 格式的转换
- 添加模型名映射机制（Claude 模型名 → iFlow 模型名）
- 支持 Anthropic 格式的 system 和 content 块解析
- 更新 API 端点文档，说明 /v1/messages 兼容 Claude Code
- 修正表格格式和文档排版